### PR TITLE
Fix cartpole always using 0 as seed.

### DIFF
--- a/exps/environments/cart_pole/cart_pole_run.py
+++ b/exps/environments/cart_pole/cart_pole_run.py
@@ -20,9 +20,10 @@ args.num_iter = 200
 args.gamma = 0.99
 weight_decay = 1e-4
 args.optimizer_ = Adam
+args.seed = 0
 
 set_random_seed(args.seed)
-env = GymEnvironment(args.env_name, 0)
+env = GymEnvironment(args.env_name, args.seed)
 env.add_wrapper(RandomActionWrapper, p=args.random_action_p)
 
 agent = QREPSAgent.default(env, **vars(args), weight_decay=weight_decay)


### PR DESCRIPTION
The seed in the cartpole env is currently fixed to 0, which does not work with the launch of all experiments.
When using other seeds the current performance is not very good. 

This can be fixed by optimizing the hyperparameters.
My quick and dirty optimization arrived at eta=1.0, alpha=0.1 and lr=0.02 which seems to be more in line with the rest of the environments.

If you want to discuss any of this in-depth, I would be very happy to hear from you!